### PR TITLE
Update extension to also support VS2019

### DIFF
--- a/VisualStudio/Installer/source.extension.vsixmanifest
+++ b/VisualStudio/Installer/source.extension.vsixmanifest
@@ -10,7 +10,7 @@
         <Tags>Sitecore, Helix, Project templates, Solution templates</Tags>
     </Metadata>
     <Installation AllUsers="true">
-        <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -22,6 +22,6 @@
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="LaubPlusCo.Foundation.Helix.Templating" Path="|LaubPlusCo.Foundation.Helix.Templating|" AssemblyName="|LaubPlusCo.Foundation.Helix.Templating;AssemblyName|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Per Mads Kristensen (MSFT Sr PM of VS Extensibility), it's a manifest-only change... https://devblogs.microsoft.com/visualstudio/how-to-upgrade-extensions-to-support-visual-studio-2019/